### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Issues + Notes
 
 * The LDAP dn is specific to your Active Directory. Talk to whoever manages it to figure out what would work best.
 * ***Because the package binds/authenticates with LDAP server-side, the user/password are sent to the server unencrypted. I still need to figure out a solution for this.***
-* Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64).
+* Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64). As a workaround, you can re-install the included dtrace-provider NPM package: `<project-root>/.meteor/local/build/programs/server/npm/typ_ldapjs/node_modules/ldapjs$ sudo npm install dtrace-provider`
 
 
 Going Forward


### PR DESCRIPTION
Apparently the build process doesn't work that well. If you compare that folder containing the dtrace-provider with a native NPM install, you see the missing .node executable. Responsible for creating this file seems to be https://github.com/chrisa/libusdt

Could it be that the missing file might have something to do with the link from .meteor/local/build/programs/server/npm/typ_ldapjs/node-modules to ~/.meteor/packages/typ_ldapjs/.0.7.3.19of61p++os+web.browser+web.cordova/npm/node_modules?

I think without a verbose mode for the "add" CLI command, it's hard to figure out what went wrong.