### PR TITLE
Update dependencies for new meteor 1.2.x projects.

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,7 +13,10 @@ Package.onUse(function(api) {
   api.use(['templating'], 'client');
   api.use(['typ:ldapjs@0.7.3'], 'server');
 
-  api.use(['accounts-base', 'accounts-password'], 'server');
+  api.use('accounts-base', 'server');
+  api.imply('accounts-base', ['client', 'server']);
+
+  api.use('check');
 
   api.addFiles(['ldap_client.js'], 'client');
   api.addFiles(['ldap_server.js'], 'server');
@@ -21,4 +24,3 @@ Package.onUse(function(api) {
   api.export('LDAP', 'server');
   api.export('LDAP_DEFAULTS', 'server');
 });
-


### PR DESCRIPTION
This works for me.. [This stackoverflow answer](http://stackoverflow.com/questions/28442884/meteor-uncaught-referenceerror-accounts-is-not-defined#answer-28444681) suggests accounts-password is required to expose the Accounts package (required for both client and server with this package). It may have been the case for older versions of meteor (I haven't been able to test it), but only accounts-base is required in 1.2.

Fixes #9 