### PR TITLE
LDAP search before bind and LDAPS support

### DIFF
--- a/ldap_client.js
+++ b/ldap_client.js
@@ -3,41 +3,41 @@
 // on any particular call (if you have multiple ldap servers you'd like to connect to)
 // You'll likely want to set the dn value here {dn: "..."}
 Meteor.loginWithLDAP = function(user, password, customLdapOptions, callback) {
-	// Retrieve arguments as array
-	var args = [];
-	for (var i = 0; i < arguments.length; i++) {
-	    args.push(arguments[i]);
-	}
-	// Pull username and password
-	user = args.shift();
-	password = args.shift();
-	
-	// Check if last argument is a function
-	// if it is, pop it off and set callback to it
-	if (typeof args[args.length-1] == 'function') callback = args.pop(); else callback = null;
-	
-	// if args still holds options item, grab it
-	if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
+    // Retrieve arguments as array
+    var args = [];
+    for (var i = 0; i < arguments.length; i++) {
+        args.push(arguments[i]);
+    }
+    // Pull username and password
+    user = args.shift();
+    password = args.shift();
 
-	// Set up loginRequest object
-	var loginRequest = _.defaults({
-		username: user,
-		ldapPass: password
-	}, {
-		ldap: true,
-		ldapOptions: customLdapOptions
-	});
+    // Check if last argument is a function
+    // if it is, pop it off and set callback to it
+    if (typeof args[args.length-1] == 'function') callback = args.pop(); else callback = null;
 
-	Accounts.callLoginMethod({
-		// Call login method with ldap = true
-		// This will hook into our login handler for ldap
-		methodArguments: [loginRequest],
-		userCallback: function(error, result) {
-			if (error) {
-				callback && callback(error);
-			} else {
-				callback && callback();
-			}
-		}
-	});
+    // if args still holds options item, grab it
+    if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
+
+    // Set up loginRequest object
+    var loginRequest = _.defaults({
+        username: user,
+        ldapPass: password
+    }, {
+        ldap: true,
+        ldapOptions: customLdapOptions
+    });
+
+    Accounts.callLoginMethod({
+        // Call login method with ldap = true
+        // This will hook into our login handler for ldap
+        methodArguments: [loginRequest],
+        userCallback: function(error, result) {
+            if (error) {
+                callback && callback(error);
+            } else {
+                callback && callback();
+            }
+        }
+    });
 }

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -5,12 +5,15 @@ Future = Npm.require('fibers/future');
 // dn should appear in normal ldap format of comma separated attribute=value
 // e.g. "uid=someuser,cn=users,dc=somevalue"
 LDAP_DEFAULTS = {
-	url: false,
-	port: '389',
-	dn: false,
-	createNewUser: true,
-	defaultDomain: false,
-	searchResultsProfileMap: false
+    url: false,
+    port: '389',
+    dn: false,
+    createNewUser: true,
+    defaultDomain: false,
+    searchResultsProfileMap: false,
+    base: null,
+    search: '(objectclass=*)',
+    ldapsCertificate: false
 };
 
 /**
@@ -18,22 +21,22 @@ LDAP_DEFAULTS = {
  @constructor
  */
 var LDAP = function(options) {
-	// Set options
-	this.options = _.defaults(options, LDAP_DEFAULTS);
+    // Set options
+    this.options = _.defaults(options, LDAP_DEFAULTS);
 
-	// Make sure options have been set
-	try {
-		check(this.options.url, String);
-		check(this.options.dn, String);
-	} catch (e) {
-		throw new Meteor.Error("Bad Defaults", "Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!");
-	}
+    // Make sure options have been set
+    try {
+        check(this.options.url, String);
+        //check(this.options.dn, String);
+    } catch (e) {
+        throw new Meteor.Error("Bad Defaults", "Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!");
+    }
 
-	// Because NPM ldapjs module has some binary builds,
-	// We had to create a wraper package for it and build for
-	// certain architectures. The package typ:ldap-js exports
-	// "MeteorWrapperLdapjs" which is a wrapper for the npm module
-	this.ldapjs = MeteorWrapperLdapjs;
+    // Because NPM ldapjs module has some binary builds,
+    // We had to create a wraper package for it and build for
+    // certain architectures. The package typ:ldap-js exports
+    // "MeteorWrapperLdapjs" which is a wrapper for the npm module
+    this.ldapjs = MeteorWrapperLdapjs;
 };
 
 /**
@@ -42,87 +45,185 @@ var LDAP = function(options) {
  *
  * @method ldapCheck
  *
- * @param {Object} options  Object with username, ldapPass and overrides for LDAP_DEFAULTS object
+ * @param {Object} options  Object with username, ldapPass and overrides for LDAP_DEFAULTS object.
+ * Additionally the searchBeforeBind parameter can be specified, which is used to search for the DN
+ * if not provided.
  */
 LDAP.prototype.ldapCheck = function(options) {
+    var self = this;
 
-	var self = this;
+    options = options || {};
 
-	options = options || {};
+    if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
 
-	if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
-
-		var ldapAsyncFut = new Future();
-
-
-		// Create ldap client
-		var fullUrl = self.options.url + ':' + self.options.port;
-		var client = self.ldapjs.createClient({
-			url: fullUrl
-		});
-
-		// Slide @xyz.whatever from username if it was passed in
-		// and replace it with the domain specified in defaults
-		var emailSliceIndex = options.username.indexOf('@');
-		var username;
-		var domain = self.options.defaultDomain;
-
-		// If user appended email domain, strip it out
-		// And use the defaults.defaultDomain if set
-		if (emailSliceIndex !== -1) {
-			username = options.username.substring(0, emailSliceIndex);
-			domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
-		} else {
-			username = options.username;
-		}
+        var ldapAsyncFut = new Future();
 
 
-		//Attempt to bind to ldap server with provided info
-		client.bind(self.options.dn, options.ldapPass, function(err) {
-			try {
-				if (err) {
-					// Bind failure, return error
-					throw new Meteor.Error(err.code, err.message);
-				} else {
-					// Bind auth successful
-					// Create return object
-					var retObject = {
-						username: username,
-						searchResults: null
-					};
-					// Set email on return object
-					retObject.email = domain ? username + '@' + domain : false;
+        // Create ldap client
+        var fullUrl = self.options.url + ':' + self.options.port;
+        var client = null;
 
-					// Return search results if specified
-					if (self.options.searchResultsProfileMap) {
-						client.search(self.options.dn, {}, function(err, res) {
+        if (self.options.url.indexOf('ldaps://') == 0) {
+            client = self.ldapjs.createClient({
+                url: fullUrl,
+                tlsOptions: {
+                    ca: [ self.options.ldapsCertificate ]
+                }
+            });
+        }
+        else {
+            client = self.ldapjs.createClient({
+                url: fullUrl
+            });
+        }
 
-							res.on('searchEntry', function(entry) {
-								// Add entry results to return object
-								retObject.searchResults = entry.object;
+        // Slide @xyz.whatever from username if it was passed in
+        // and replace it with the domain specified in defaults
+        var emailSliceIndex = options.username.indexOf('@');
+        var username;
+        var domain = self.options.defaultDomain;
 
-								ldapAsyncFut.return(retObject);
-							});
+        // If user appended email domain, strip it out
+        // And use the defaults.defaultDomain if set
+        if (emailSliceIndex !== -1) {
+            username = options.username.substring(0, emailSliceIndex);
+            domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
+        } else {
+            username = options.username;
+        }
 
-						});
-					}
-					// No search results specified, return username and email object
-					else {
-						ldapAsyncFut.return(retObject);
-					}
-				}
-			} catch (e) {
-				ldapAsyncFut.return({
-					error: e
-				});
-			}
-		});
 
-		return ldapAsyncFut.wait();
+        // DN is provided
+        if (self.options.dn !== false) {
+            //Attempt to bind to ldap server with provided info
+            client.bind(self.options.dn, options.ldapPass, function(err) {
+                try {
+                    if (err) {
+                        // Bind failure, return error
+                        throw new Meteor.Error(err.code, err.message);
+                    } else {
+                        // Bind auth successful
+                        // Create return object
+                        var retObject = {
+                            username: self.options.dn,
+                            searchResults: null
+                        };
+                        // Set email on return object
+                        retObject.email = domain ? username + '@' + domain : false;
 
-	} else {
-		throw new Meteor.Error(403, "Missing LDAP Auth Parameter");
-	}
+                        // Return search results if specified
+                        if (self.options.searchResultsProfileMap) {
+
+                            // construct list of ldap attributes to fetch
+                            var attributes = [];
+                            self.options.searchResultsProfileMap.map(function(item) {
+                                attributes.push(item.resultKey);
+                            });
+
+                            // use base if given, else the dn for the ldap search
+                            var searchBase = self.options.base || self.options.dn;
+                            var searchOptions = {
+                                scope: 'sub',
+                                sizeLimit: 1,
+                                attributes: attributes,
+                                filter: self.options.search
+                            }
+
+                            client.search(searchBase, searchOptions, function(err, res) {
+                                res.on('searchEntry', function(entry) {
+                                    // Add entry results to return object
+                                    retObject.searchResults = entry.object;
+                                    ldapAsyncFut.return(retObject);
+                                });
+                            });
+                        }
+                        // No search results specified, return username and email object
+                        else {
+                            ldapAsyncFut.return(retObject);
+                        }
+                    }
+                } catch (e) {
+                    ldapAsyncFut.return({
+                        error: e
+                    });
+                }
+            });
+        }
+        else if (self.options.searchBeforeBind !== undefined) {
+            // dn not provided, search for DN
+
+            // initialize result
+            var retObject = {
+                username: username,
+                email: domain ? username + '@' + domain : false,
+                emptySearch: true,
+                searchResults: {}
+            };
+
+            // compile attribute list to return
+            var searchAttributes = ['dn'];
+            self.options.searchResultsProfileMap.map(function(item) {
+                searchAttributes.push(item.resultKey);
+            });
+
+
+            var filter = self.options.search;
+            Object.keys(options.ldapOptions.searchBeforeBind).forEach(function(searchKey) {
+                filter = '&' + filter + '(' + searchKey + '=' + options.ldapOptions.searchBeforeBind[searchKey] + ')';
+            });
+            var searchOptions = {
+                scope: 'sub',
+                sizeLimit: 1,
+                filter: filter
+            }
+
+            // perform LDAP search to determine DN
+            client.search(self.options.base, searchOptions, function(err, res) {
+                retObject.emptySearch = true;
+                res.on('searchEntry', function(entry) {
+                    retObject.dn = entry.objectName;
+                    retObject.username = retObject.dn;
+                    retObject.emptySearch = false;
+
+                    // Return search results if specified
+                    if (self.options.searchResultsProfileMap) {
+                        // construct list of ldap attributes to fetch
+                        var attributes = [];
+                        self.options.searchResultsProfileMap.map(function (item) {
+                            retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
+                        });
+                    }
+
+                    // use the determined DN to bind
+                    client.bind(entry.objectName, options.ldapPass, function(err) {
+                        try {
+                            if (err) {
+                                throw new Meteor.Error(err.code, err.message);
+                            }
+                            else {
+                                ldapAsyncFut.return(retObject);
+                            }
+                        }
+                        catch (e) {
+                            ldapAsyncFut.return({
+                                error: e
+                            });
+                        }
+                    });
+                });
+                res.on('end', function(result) {
+                    if (retObject.dn === undefined) {
+                        ldapAsyncFut.return(retObject);
+                    }
+                });
+            });
+        }
+
+        return ldapAsyncFut.wait();
+
+    } else {
+        throw new Meteor.Error(403, "Missing LDAP Auth Parameter");
+    }
 
 };
 
@@ -132,93 +233,100 @@ LDAP.prototype.ldapCheck = function(options) {
 // Meteor.loginWithLDAP on client side
 // @param {Object} loginRequest will consist of username, ldapPass, ldap, and ldapOptions
 Accounts.registerLoginHandler("ldap", function(loginRequest) {
-	// If "ldap" isn't set in loginRequest object,
-	// then this isn't the proper handler (return undefined)
-	if (!loginRequest.ldap) {
-		return undefined;
-	}
+    // If "ldap" isn't set in loginRequest object,
+    // then this isn't the proper handler (return undefined)
+    if (!loginRequest.ldap) {
+        return undefined;
+    }
 
-	// Instantiate LDAP with options
-	var userOptions = loginRequest.ldapOptions || {};
-	var ldapObj = new LDAP(userOptions);
+    // Instantiate LDAP with options
+    var userOptions = loginRequest.ldapOptions || {};
+    var ldapObj = new LDAP(userOptions);
 
-	// Call ldapCheck and get response
-	var ldapResponse = ldapObj.ldapCheck(loginRequest);
+    // Call ldapCheck and get response
+    var ldapResponse = ldapObj.ldapCheck(loginRequest);
 
-	if (ldapResponse.error) {
-		return {
-			userId: null,
-			error: ldapResponse.error
-		}
-	} else {
-		// Set initial userId and token vals
-		var userId = null;
-		var stampedToken = {
-			token: null
-		};
+    if (ldapResponse.error) {
+        return {
+            userId: null,
+            error: ldapResponse.error
+        }
+    }
+    else if (ldapResponse.emptySearch == true) {
+        return {
+            userId: null,
+            error: 'User not found'
+        }
+    }
+    else {
+        // Set initial userId and token vals
+        var userId = null;
+        var stampedToken = {
+            token: null
+        };
 
-		// Look to see if user already exists
-		var user = Meteor.users.findOne({
-			username: ldapResponse.username
-		});
+        // Look to see if user already exists
+        var user = Meteor.users.findOne({
+            username: ldapResponse.username
+        });
 
-		// Login user if they exist
-		if (user) {
-			userId = user._id;
+        // Login user if they exist
+        if (user) {
+            userId = user._id;
 
-			// Create hashed token so user stays logged in
-			stampedToken = Accounts._generateStampedLoginToken();
-			var hashStampedToken = Accounts._hashStampedToken(stampedToken);
-			// Update the user's token in mongo
-			Meteor.users.update(userId, {
-				$push: {
-					'services.resume.loginTokens': hashStampedToken
-				}
-			});
-		}
-		// Otherwise create user if option is set
-		else if (ldapObj.options.createNewUser) {
-			var userObject = {
-				username: ldapResponse.username
-			};
-			// Set email
-			if (ldapResponse.email) userObject.email = ldapResponse.email;
+            // Create hashed token so user stays logged in
+            stampedToken = Accounts._generateStampedLoginToken();
+            var hashStampedToken = Accounts._hashStampedToken(stampedToken);
+            // Update the user's token in mongo
+            Meteor.users.update(userId, {
+                $push: {
+                    'services.resume.loginTokens': hashStampedToken
+                }
+            });
+        }
+        // Otherwise create user if option is set
+        else if (ldapObj.options.createNewUser) {
+            var userObject = {
+                username: ldapResponse.username
+            };
+            // Set email
+            if (ldapResponse.email) userObject.email = ldapResponse.email;
 
-			// Set profile values if specified in searchResultsProfileMap
-			if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
+            // Set profile values if specified in searchResultsProfileMap
+            if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
 
-				var profileMap = ldapObj.options.searchResultsProfileMap;
-				var profileObject = {};
+                var profileMap = ldapObj.options.searchResultsProfileMap;
+                var profileObject = {};
 
-				// Loop through profileMap and set values on profile object
-				for (var i = 0; i < profileMap.length; i++) {
-					var resultKey = profileMap[i].resultKey;
+                // Loop through profileMap and set values on profile object
+                for (var i = 0; i < profileMap.length; i++) {
+                    var resultKey = profileMap[i].resultKey;
 
-					// If our search results have the specified property, set the profile property to its value
-					if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
-						profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
-					}
+                    // If our search results have the specified property, set the profile property to its value
+                    if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
+                        profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
+                    }
 
-				}
-				// Set userObject profile
-				userObject.profile = profileObject;
-			}
+                }
+                // Set userObject profile
+                userObject.profile = profileObject;
+            }
 
 
-			userId = Accounts.createUser(userObject);
-		} else {
-			// Ldap success, but no user created
-			return {
-				userId: null,
-				error: "LDAP Authentication succeded, but no user exists in Mongo. Either create a user for this email or set LDAP_DEFAULTS.createNewUser to true"
-			};
-		}
+            userId = Accounts.createUser(userObject);
+        } else {
+            // Ldap success, but no user created
+            return {
+                userId: null,
+                error: "LDAP Authentication succeeded, but no user exists in MongoDB. Either create a user for this email or set LDAP_DEFAULTS.createNewUser to true"
+            };
+        }
 
-		return {
-			userId: userId,
-			token: stampedToken.token
-		};
-	}
+        return {
+            userId: userId,
+            token: stampedToken.token
+        };
+    }
 
-	return undefined;
+    return undefined;
 });

--- a/package.js
+++ b/package.js
@@ -1,24 +1,23 @@
 Package.describe({
   name: 'typ:accounts-ldap',
-  version: '0.0.1',
-  summary: 'Accounts login handler for LDAP using ldapjs from npm',
+  version: '1.0.0',
+  summary: 'Accounts login handler for LDAP using ldapjs and allowing to search anonymously for the DN before binding.',
   git: 'https://github.com/typ90/meteor-accounts-ldap',
   documentation: 'README.md'
 });
 
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.0.3.1');
+    api.versionsFrom('1.0.3.1');
 
-  api.use(['templating'], 'client');
-  api.use(['typ:ldapjs@0.7.3'], 'server');
+    api.use(['templating'], 'client');
+    api.use(['typ:ldapjs@0.7.3'], 'server');
 
-  api.use(['accounts-base', 'accounts-password'], 'server');
+    api.use(['accounts-base', 'accounts-password'], 'server');
 
-  api.addFiles(['ldap_client.js'], 'client');
-  api.addFiles(['ldap_server.js'], 'server');
+    api.addFiles(['ldap_client.js'], 'client');
+    api.addFiles(['ldap_server.js'], 'server');
 
-  api.export('LDAP', 'server');
-  api.export('LDAP_DEFAULTS', 'server');
+    api.export('LDAP', 'server');
+    api.export('LDAP_DEFAULTS', 'server');
 });
-


### PR DESCRIPTION
I added another option `searchBeforeBind` to the client-side call `loginWithLdap` in case the `dn` is not known or cannot be determined from the login name.

If no `dn` is configured or provided, the server-side logic will first call an LDAP search with the provided search parameters (+ configured search base) to determine the record containing the `dn`. Then the standard bind is performed using the password provided using the `dn`.

When the LDAP client is initialised I also added support to provide an SSL certificate to the client to comply with more strict security regulations and support `ldaps://` support.