### PR TITLE
Add support for non-anonymous search

### DIFF
--- a/ldap_client.js
+++ b/ldap_client.js
@@ -2,7 +2,7 @@
 // customLdapOptions should be passed in if you want to override LDAP_DEFAULTS
 // on any particular call (if you have multiple ldap servers you'd like to connect to)
 // You'll likely want to set the dn value here {dn: "..."}
-Meteor.loginWithLDAP = function(user, password, customLdapOptions, callback) {
+Meteor.loginWithLDAP = function (user, password, customLdapOptions, callback) {
     // Retrieve arguments as array
     var args = [];
     for (var i = 0; i < arguments.length; i++) {
@@ -14,7 +14,7 @@ Meteor.loginWithLDAP = function(user, password, customLdapOptions, callback) {
 
     // Check if last argument is a function
     // if it is, pop it off and set callback to it
-    if (typeof args[args.length-1] == 'function') callback = args.pop(); else callback = null;
+    if (typeof args[args.length - 1] == 'function') callback = args.pop(); else callback = null;
 
     // if args still holds options item, grab it
     if (args.length > 0) customLdapOptions = args.shift(); else customLdapOptions = {};
@@ -32,7 +32,7 @@ Meteor.loginWithLDAP = function(user, password, customLdapOptions, callback) {
         // Call login method with ldap = true
         // This will hook into our login handler for ldap
         methodArguments: [loginRequest],
-        userCallback: function(error, result) {
+        userCallback: function (error, result) {
             if (error) {
                 callback && callback(error);
             } else {

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -5,40 +5,40 @@ Future = Npm.require('fibers/future');
 // dn should appear in normal ldap format of comma separated attribute=value
 // e.g. 'uid=someuser,cn=users,dc=somevalue'
 LDAP_DEFAULTS = {
-	url: false,
-	port: '389',
-	dn: false,
-	searchDN: false,
-	searchCredentials: false,
-	createNewUser: true,
-	defaultDomain: false,
-	searchResultsProfileMap: false,
-	base: null,
-	search: '(objectclass=*)',
-	ldapsCertificate: false
+    url: false,
+    port: '389',
+    dn: false,
+    searchDN: false,
+    searchCredentials: false,
+    createNewUser: true,
+    defaultDomain: false,
+    searchResultsProfileMap: false,
+    base: null,
+    search: '(objectclass=*)',
+    ldapsCertificate: false
 };
 
 /**
  @class LDAP
  @constructor
  */
-var LDAP = function(options) {
-  // Set options
-  this.options = _.defaults(options, LDAP_DEFAULTS);
+var LDAP = function (options) {
+    // Set options
+    this.options = _.defaults(options, LDAP_DEFAULTS);
 
-  // Make sure options have been set
-  try {
-      check(this.options.url, String);
-      //check(this.options.dn, String);
-  } catch (e) {
-      throw new Meteor.Error('Bad Defaults', 'Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!');
-  }
+    // Make sure options have been set
+    try {
+        check(this.options.url, String);
+        //check(this.options.dn, String);
+    } catch (e) {
+        throw new Meteor.Error('Bad Defaults', 'Options not set. Make sure to set LDAP_DEFAULTS.url and LDAP_DEFAULTS.dn!');
+    }
 
-  // Because NPM ldapjs module has some binary builds,
-  // We had to create a wraper package for it and build for
-  // certain architectures. The package typ:ldap-js exports
-  // 'MeteorWrapperLdapjs' which is a wrapper for the npm module
-  this.ldapjs = MeteorWrapperLdapjs;
+    // Because NPM ldapjs module has some binary builds,
+    // We had to create a wraper package for it and build for
+    // certain architectures. The package typ:ldap-js exports
+    // 'MeteorWrapperLdapjs' which is a wrapper for the npm module
+    this.ldapjs = MeteorWrapperLdapjs;
 };
 
 /**
@@ -51,63 +51,63 @@ var LDAP = function(options) {
  * Additionally the searchBeforeBind parameter can be specified, which is used to search for the DN
  * if not provided.
  */
-LDAP.prototype.ldapCheck = function(options) {
+LDAP.prototype.ldapCheck = function (options) {
 
-	var self = this;
+    var self = this;
 
-	options = options || {};
+    options = options || {};
 
-	if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
+    if (options.hasOwnProperty('username') && options.hasOwnProperty('ldapPass')) {
 
-		var ldapAsyncFut = new Future();
-
-
-		// Create ldap client
-		var fullUrl = self.options.url + ':' + self.options.port;
-		var client = null;
-
-		if (self.options.url.indexOf('ldaps://') === 0) {
-			client = self.ldapjs.createClient({
-				url: fullUrl,
-				tlsOptions: {
-					ca: [ self.options.ldapsCertificate ]
-				}
-			});
-		}
-		else {
-			client = self.ldapjs.createClient({
-				url: fullUrl
-			});
-		}
+        var ldapAsyncFut = new Future();
 
 
-		// Slide @xyz.whatever from username if it was passed in
-		// and replace it with the domain specified in defaults
-		var emailSliceIndex = options.username.indexOf('@');
-		var username;
-		var domain = self.options.defaultDomain;
+        // Create ldap client
+        var fullUrl = self.options.url + ':' + self.options.port;
+        var client = null;
 
-		// If user appended email domain, strip it out
-		// And use the defaults.defaultDomain if set
-		if (emailSliceIndex !== -1) {
-			username = options.username.substring(0, emailSliceIndex);
-			domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
-		} else {
-			username = options.username;
-		}
+        if (self.options.url.indexOf('ldaps://') === 0) {
+            client = self.ldapjs.createClient({
+                url: fullUrl,
+                tlsOptions: {
+                    ca: [self.options.ldapsCertificate]
+                }
+            });
+        }
+        else {
+            client = self.ldapjs.createClient({
+                url: fullUrl
+            });
+        }
 
 
-		// If DN is provided, use it to bind
-		if (self.options.dn) {
-			// Attempt to bind to ldap server with provided info
-			client.bind(self.options.searchDN || self.options.dn, self.options.searchCredentials || options.ldapPass, function(err) {
-				try {
-					if (err) {
-						// Bind failure, return error
-						throw new Meteor.Error(err.code, err.message);
-					}
+        // Slide @xyz.whatever from username if it was passed in
+        // and replace it with the domain specified in defaults
+        var emailSliceIndex = options.username.indexOf('@');
+        var username;
+        var domain = self.options.defaultDomain;
 
-					var handleSearchProfile = function(retObject, bindAfterSearch) {
+        // If user appended email domain, strip it out
+        // And use the defaults.defaultDomain if set
+        if (emailSliceIndex !== -1) {
+            username = options.username.substring(0, emailSliceIndex);
+            domain = domain || options.username.substring((emailSliceIndex + 1), options.username.length);
+        } else {
+            username = options.username;
+        }
+
+
+        // If DN is provided, use it to bind
+        if (self.options.dn) {
+            // Attempt to bind to ldap server with provided info
+            client.bind(self.options.searchDN || self.options.dn, self.options.searchCredentials || options.ldapPass, function (err) {
+                try {
+                    if (err) {
+                        // Bind failure, return error
+                        throw new Meteor.Error(err.code, err.message);
+                    }
+
+                    var handleSearchProfile = function (retObject, bindAfterSearch) {
 
                         // construct list of ldap attributes to fetch
                         var attributes = [];
@@ -153,103 +153,103 @@ LDAP.prototype.ldapCheck = function(options) {
                             });
 
                         });
-					};
+                    };
 
-					var retObject = {
-						username: username,
-						searchResults: null,
-						email: domain ? username + '@' + domain : false
-					};
+                    var retObject = {
+                        username: username,
+                        searchResults: null,
+                        email: domain ? username + '@' + domain : false
+                    };
 
-					if (self.options.searchDN) {
-						handleSearchProfile(retObject, true);
-					} else if (self.options.searchResultsProfileMap){
-						handleSearchProfile(retObject, false);
-					} else {
-						ldapAsyncFut.return(retObject);
-					}
+                    if (self.options.searchDN) {
+                        handleSearchProfile(retObject, true);
+                    } else if (self.options.searchResultsProfileMap) {
+                        handleSearchProfile(retObject, false);
+                    } else {
+                        ldapAsyncFut.return(retObject);
+                    }
 
-				} catch (e) {
-					ldapAsyncFut.return({
-						error: e
-					});
-				}
-			});
-		}
-		// DN not provided, search for DN and use result to bind
-		else if (typeof self.options.searchBeforeBind !== undefined) {
-			// initialize result
-			var retObject = {
-				username: username,
-				email: domain ? username + '@' + domain : false,
-				emptySearch: true,
-				searchResults: {}
-			};
+                } catch (e) {
+                    ldapAsyncFut.return({
+                        error: e
+                    });
+                }
+            });
+        }
+        // DN not provided, search for DN and use result to bind
+        else if (typeof self.options.searchBeforeBind !== undefined) {
+            // initialize result
+            var retObject = {
+                username: username,
+                email: domain ? username + '@' + domain : false,
+                emptySearch: true,
+                searchResults: {}
+            };
 
-			// compile attribute list to return
-			var searchAttributes = ['dn'];
-			self.options.searchResultsProfileMap.map(function(item) {
-				searchAttributes.push(item.resultKey);
-			});
+            // compile attribute list to return
+            var searchAttributes = ['dn'];
+            self.options.searchResultsProfileMap.map(function (item) {
+                searchAttributes.push(item.resultKey);
+            });
 
 
-			var filter = self.options.search;
-			Object.keys(options.ldapOptions.searchBeforeBind).forEach(function(searchKey) {
-				filter = '&' + filter + '(' + searchKey + '=' + options.ldapOptions.searchBeforeBind[searchKey] + ')';
-			});
-			var searchOptions = {
-				scope: 'sub',
-				sizeLimit: 1,
-				filter: filter
-			};
+            var filter = self.options.search;
+            Object.keys(options.ldapOptions.searchBeforeBind).forEach(function (searchKey) {
+                filter = '&' + filter + '(' + searchKey + '=' + options.ldapOptions.searchBeforeBind[searchKey] + ')';
+            });
+            var searchOptions = {
+                scope: 'sub',
+                sizeLimit: 1,
+                filter: filter
+            };
 
-			// perform LDAP search to determine DN
-			client.search(self.options.base, searchOptions, function(err, res) {
-				retObject.emptySearch = true;
-				res.on('searchEntry', function(entry) {
-					retObject.dn = entry.objectName;
-					retObject.username = retObject.dn;
-					retObject.emptySearch = false;
+            // perform LDAP search to determine DN
+            client.search(self.options.base, searchOptions, function (err, res) {
+                retObject.emptySearch = true;
+                res.on('searchEntry', function (entry) {
+                    retObject.dn = entry.objectName;
+                    retObject.username = retObject.dn;
+                    retObject.emptySearch = false;
 
-					// Return search results if specified
-					if (self.options.searchResultsProfileMap) {
-						// construct list of ldap attributes to fetch
-						self.options.searchResultsProfileMap.map(function (item) {
-							retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
-						});
-					}
+                    // Return search results if specified
+                    if (self.options.searchResultsProfileMap) {
+                        // construct list of ldap attributes to fetch
+                        self.options.searchResultsProfileMap.map(function (item) {
+                            retObject.searchResults[item.resultKey] = entry.object[item.resultKey];
+                        });
+                    }
 
-					// use the determined DN to bind
-					client.bind(entry.objectName, options.ldapPass, function(err) {
-						try {
-							if (err) {
-								throw new Meteor.Error(err.code, err.message);
-							}
-							else {
-								ldapAsyncFut.return(retObject);
-							}
-						}
-						catch (e) {
-							ldapAsyncFut.return({
-								error: e
-							});
-						}
-					});
-				});
-				// If no dn is found, return as is.
-				res.on('end', function(result) {
-					if (retObject.dn === undefined) {
-						ldapAsyncFut.return(retObject);
-					}
-				});
-			});
-		}
+                    // use the determined DN to bind
+                    client.bind(entry.objectName, options.ldapPass, function (err) {
+                        try {
+                            if (err) {
+                                throw new Meteor.Error(err.code, err.message);
+                            }
+                            else {
+                                ldapAsyncFut.return(retObject);
+                            }
+                        }
+                        catch (e) {
+                            ldapAsyncFut.return({
+                                error: e
+                            });
+                        }
+                    });
+                });
+                // If no dn is found, return as is.
+                res.on('end', function (result) {
+                    if (retObject.dn === undefined) {
+                        ldapAsyncFut.return(retObject);
+                    }
+                });
+            });
+        }
 
-		return ldapAsyncFut.wait();
+        return ldapAsyncFut.wait();
 
-	} else {
-		throw new Meteor.Error(403, 'Missing LDAP Auth Parameter');
-	}
+    } else {
+        throw new Meteor.Error(403, 'Missing LDAP Auth Parameter');
+    }
 
 };
 
@@ -258,101 +258,101 @@ LDAP.prototype.ldapCheck = function(options) {
 // Here we create a new LDAP instance with options passed from
 // Meteor.loginWithLDAP on client side
 // @param {Object} loginRequest will consist of username, ldapPass, ldap, and ldapOptions
-Accounts.registerLoginHandler('ldap', function(loginRequest) {
-	// If 'ldap' isn't set in loginRequest object,
-	// then this isn't the proper handler (return undefined)
-	if (!loginRequest.ldap) {
-		return undefined;
-	}
+Accounts.registerLoginHandler('ldap', function (loginRequest) {
+    // If 'ldap' isn't set in loginRequest object,
+    // then this isn't the proper handler (return undefined)
+    if (!loginRequest.ldap) {
+        return undefined;
+    }
 
-	// Instantiate LDAP with options
-	var userOptions = loginRequest.ldapOptions || {};
-	var ldapObj = new LDAP(userOptions);
+    // Instantiate LDAP with options
+    var userOptions = loginRequest.ldapOptions || {};
+    var ldapObj = new LDAP(userOptions);
 
-	// Call ldapCheck and get response
-	var ldapResponse = ldapObj.ldapCheck(loginRequest);
+    // Call ldapCheck and get response
+    var ldapResponse = ldapObj.ldapCheck(loginRequest);
 
-	if (ldapResponse.error) {
-		return {
-			userId: null,
-			error: ldapResponse.error
-		};
-	}
-	else if (ldapResponse.emptySearch) {
-		return {
-			userId: null,
-			error: new Meteor.Error(403, 'User not found in LDAP')
-		};
-	}
-	else {
-		// Set initial userId and token vals
-		var userId = null;
-		var stampedToken = {
-			token: null
-		};
+    if (ldapResponse.error) {
+        return {
+            userId: null,
+            error: ldapResponse.error
+        };
+    }
+    else if (ldapResponse.emptySearch) {
+        return {
+            userId: null,
+            error: new Meteor.Error(403, 'User not found in LDAP')
+        };
+    }
+    else {
+        // Set initial userId and token vals
+        var userId = null;
+        var stampedToken = {
+            token: null
+        };
 
-		// Look to see if user already exists
-		var user = Meteor.users.findOne({
-			username: ldapResponse.username
-		});
+        // Look to see if user already exists
+        var user = Meteor.users.findOne({
+            username: ldapResponse.username
+        });
 
-		// Login user if they exist
-		if (user) {
-			userId = user._id;
+        // Login user if they exist
+        if (user) {
+            userId = user._id;
 
-			// Create hashed token so user stays logged in
-			stampedToken = Accounts._generateStampedLoginToken();
-			var hashStampedToken = Accounts._hashStampedToken(stampedToken);
-			// Update the user's token in mongo
-			Meteor.users.update(userId, {
-				$push: {
-					'services.resume.loginTokens': hashStampedToken
-				}
-			});
-		}
-		// Otherwise create user if option is set
-		else if (ldapObj.options.createNewUser) {
-			var userObject = {
-				username: ldapResponse.username
-			};
-			// Set email
-			if (ldapResponse.email) userObject.email = ldapResponse.email;
+            // Create hashed token so user stays logged in
+            stampedToken = Accounts._generateStampedLoginToken();
+            var hashStampedToken = Accounts._hashStampedToken(stampedToken);
+            // Update the user's token in mongo
+            Meteor.users.update(userId, {
+                $push: {
+                    'services.resume.loginTokens': hashStampedToken
+                }
+            });
+        }
+        // Otherwise create user if option is set
+        else if (ldapObj.options.createNewUser) {
+            var userObject = {
+                username: ldapResponse.username
+            };
+            // Set email
+            if (ldapResponse.email) userObject.email = ldapResponse.email;
 
-			// Set profile values if specified in searchResultsProfileMap
-			if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
+            // Set profile values if specified in searchResultsProfileMap
+            if (ldapResponse.searchResults && ldapObj.options.searchResultsProfileMap.length > 0) {
 
-				var profileMap = ldapObj.options.searchResultsProfileMap;
-				var profileObject = {};
+                var profileMap = ldapObj.options.searchResultsProfileMap;
+                var profileObject = {};
 
-				// Loop through profileMap and set values on profile object
-				for (var i = 0; i < profileMap.length; i++) {
-					var resultKey = profileMap[i].resultKey;
+                // Loop through profileMap and set values on profile object
+                for (var i = 0; i < profileMap.length; i++) {
+                    var resultKey = profileMap[i].resultKey;
 
-					// If our search results have the specified property, set the profile property to its value
-					if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
-						profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
-					}
+                    // If our search results have the specified property, set the profile property to its value
+                    if (ldapResponse.searchResults.hasOwnProperty(resultKey)) {
+                        profileObject[profileMap[i].profileProperty] = ldapResponse.searchResults[resultKey];
+                    }
 
-				}
-				// Set userObject profile
-				userObject.profile = profileObject;
-			}
+                }
+                // Set userObject profile
+                userObject.profile = profileObject;
+            }
 
 
-			userId = Accounts.createUser(userObject);
-		} else {
-			// Ldap success, but no user created
-            console.log('LDAP Authentication succeeded for '+ldapResponse.username+', but no user exists in Meteor. Either create the user manually or set LDAP_DEFAULTS.createNewUser to true');
-			return {
-				userId: null,
-				error: new Meteor.Error(403, 'User found in LDAP but not in application')
-			};
-		}
+            userId = Accounts.createUser(userObject);
+        } else {
+            // Ldap success, but no user created
+            console.log('LDAP Authentication succeeded for ' + ldapResponse.username + ', but no user exists in Meteor. Either create the user manually or set LDAP_DEFAULTS.createNewUser to true');
+            return {
+                userId: null,
+                error: new Meteor.Error(403, 'User found in LDAP but not in application')
+            };
+        }
 
-		return {
-			userId: userId,
-			token: stampedToken.token
-		};
-	}
+        return {
+            userId: userId,
+            token: stampedToken.token
+        };
+    }
 
 });

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -108,6 +108,7 @@ LDAP.prototype.ldapCheck = function (options) {
                     }
 
                     var handleSearchProfile = function (retObject, bindAfterSearch) {
+                        retObject.emptySearch = true;
 
                         // construct list of ldap attributes to fetch
                         var attributes = [];
@@ -134,6 +135,7 @@ LDAP.prototype.ldapCheck = function (options) {
                             }
 
                             res.on('searchEntry', function (entry) {
+                                retObject.emptySearch = false;
                                 // Add entry results to return object
                                 retObject.searchResults = entry.object;
                                 if (bindAfterSearch) {
@@ -150,6 +152,10 @@ LDAP.prototype.ldapCheck = function (options) {
                                         }
                                     })
                                 } else ldapAsyncFut.return(retObject);
+                            });
+
+                            res.on('end', function () {
+                                ldapAsyncFut.return(retObject);
                             });
 
                         });


### PR DESCRIPTION
With the LDAP I have to communicate with we require a two phase login, where the initial search is not done anonymous but after a successful bind on an authorized account. This pull requests adds support for a process where:

* A user requests login through LDAP
* The backend binds using a configured default account that allows searching
* The backend searches for the account related to the login attempt
* When successful, the backend binds the found account and uses it to login in Meteor

Also cleans up some errors that were returned in the login handler, but which did not satisfy the return type requirements of the Meteor account system.