### PR TITLE
Enhance structure and add listing option

### DIFF
--- a/ldap_server.js
+++ b/ldap_server.js
@@ -155,7 +155,7 @@ LDAP.prototype.ldapCheck = function (options) {
                             });
 
                             res.on('end', function () {
-                                if (retObject.dn === undefined && !bindAfterSearch) {
+                                if (retObject.emptySearch) {
                                     ldapAsyncFut.return(retObject);
                                 }
                             });

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -155,7 +155,7 @@ LDAP.prototype.ldapCheck = function (options) {
                             });
 
                             res.on('end', function () {
-                                if (retObject.dn === undefined) {
+                                if (retObject.dn === undefined && !bindAfterSearch) {
                                     ldapAsyncFut.return(retObject);
                                 }
                             });

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -267,7 +267,7 @@ Accounts.registerLoginHandler('ldap', function (loginRequest) {
         var stampedToken = {
             token: null
         };
-        ldapResponse.email = ldapResponse.email.toLowerCase();
+        ldapResponse.email = ldapResponse.searchResults[0].email.toLowerCase();
 
         // Look to see if user already exists
         var user = Meteor.users.findOne({

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -155,7 +155,9 @@ LDAP.prototype.ldapCheck = function (options) {
                             });
 
                             res.on('end', function () {
-                                ldapAsyncFut.return(retObject);
+                                if (retObject.dn === undefined) {
+                                    ldapAsyncFut.return(retObject);
+                                }
                             });
 
                         });


### PR DESCRIPTION
This pull request fixes some double future resolve problems introduced in the previous and adds 2 new functions:

* The ability to optionally bind after a check, to allow checking for existence without having to supply a password (required to validate if a supplied LDAP account exists when associating an application entity to an LDAP account)
* The ability to retrieve a listing of ldap accounts in the supplied dn, which makes it possible to search the directory (required for client-sided autocomplete/typeahead)