### PR TITLE
Do not call Future method when response is ended

### DIFF
--- a/ldap_server.js
+++ b/ldap_server.js
@@ -154,9 +154,11 @@ LDAP.prototype.ldapCheck = function (options) {
                                 } else ldapAsyncFut.return(retObject);
                             });
 
-                            res.on('end', function () {
-                                ldapAsyncFut.return(retObject);
-                            });
+                            // This call causes Future issue: "Future resolved more than once"
+                            // Because it is already called in searchEntry handler
+                            /*res.on('end', function () {
+                             ldapAsyncFut.return(retObject);
+                             });*/
 
                         });
                     };


### PR DESCRIPTION
Future method is already called when search entry is handled in cases that search results profile map is set